### PR TITLE
Add license to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rusty_fusion"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.80.0"
+license = "GPL-3.0-only"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This also solidifies it as GPL 3.0 only, as opposed to GPL 3.0 or later.