### PR TITLE
Retry initial database connection until it succeeds

### DIFF
--- a/config_schema.toml
+++ b/config_schema.toml
@@ -23,6 +23,9 @@ logging_level_file = 2    # ...and in the log files
 log_write_interval = 60 # how long (seconds) between log file writes
 
 #: u64
+db_conn_retry_interval = 10 # how long (seconds) to wait before retrying initial connection to DB
+
+#: u64
 live_check_time = 5  # how long (seconds) between live check packet sends.
                      # if this amount of time passes *again* after sending a live check,
                      # that wasn't answered, the client will be disconnected

--- a/src/bin/login/main.rs
+++ b/src/bin/login/main.rs
@@ -36,6 +36,8 @@ async fn main() -> FFResult<()> {
     color_eyre::install().unwrap();
     let _cleanup = Cleanup {};
 
+    db_init(Severity::Warning).await?;
+
     let log_rx = log_init();
     let config = config_init()?;
     let mut logger = Logger::new(log_rx, &config.login.log_path.get());
@@ -49,7 +51,6 @@ async fn main() -> FFResult<()> {
         None
     };
 
-    db_init(Severity::Warning).await?;
     tdata_init()?;
 
     let mut tui_timer = util::make_timer(Duration::from_millis(250), true);

--- a/src/bin/login/main.rs
+++ b/src/bin/login/main.rs
@@ -36,8 +36,6 @@ async fn main() -> FFResult<()> {
     color_eyre::install().unwrap();
     let _cleanup = Cleanup {};
 
-    db_init(Severity::Warning).await?;
-
     let log_rx = log_init();
     let config = config_init()?;
     let mut logger = Logger::new(log_rx, &config.login.log_path.get());
@@ -59,6 +57,10 @@ async fn main() -> FFResult<()> {
         false,
     );
     let mut shard_conn_timer = util::make_timer(Duration::from_millis(250), false);
+    let mut db_conn_timer = util::make_timer(
+        Duration::from_secs(config.shard.login_server_conn_interval.get()), // TODO: config
+        true,
+    );
     let mut monitor_timer = util::make_timer(
         Duration::from_secs(config.login.monitor_interval.get()),
         false,
@@ -187,6 +189,9 @@ async fn main() -> FFResult<()> {
                 let clients = server.get_clients().await;
                 state.lock().await
                     .process_shard_connection_requests(&clients, SystemTime::now());
+            }
+            _ = db_conn_timer.tick() => {
+                log_if_failed(db_init(Severity::Fatal).await);
             }
             _ = monitor_timer.tick() => {
                 if monitor_enabled {

--- a/src/bin/login/main.rs
+++ b/src/bin/login/main.rs
@@ -58,7 +58,7 @@ async fn main() -> FFResult<()> {
     );
     let mut shard_conn_timer = util::make_timer(Duration::from_millis(250), false);
     let mut db_conn_timer = util::make_timer(
-        Duration::from_secs(config.shard.login_server_conn_interval.get()), // TODO: config
+        Duration::from_secs(config.general.db_conn_retry_interval.get()),
         true,
     );
     let mut monitor_timer = util::make_timer(

--- a/src/bin/login/main.rs
+++ b/src/bin/login/main.rs
@@ -191,7 +191,7 @@ async fn main() -> FFResult<()> {
                     .process_shard_connection_requests(&clients, SystemTime::now());
             }
             _ = db_conn_timer.tick() => {
-                log_if_failed(db_init(Severity::Fatal).await);
+                log_if_failed(db_init(Severity::Warning).await);
             }
             _ = monitor_timer.tick() => {
                 if monitor_enabled {

--- a/src/bin/shard/main.rs
+++ b/src/bin/shard/main.rs
@@ -35,8 +35,6 @@ async fn main() -> FFResult<()> {
     color_eyre::install().unwrap();
     let _cleanup = Cleanup {};
 
-    db_init(Severity::Fatal).await?;
-
     let log_rx = log_init();
     let config = config_init()?;
     let mut logger = Logger::new(log_rx, &config.shard.log_path.get());
@@ -60,6 +58,10 @@ async fn main() -> FFResult<()> {
     );
     let mut login_conn_timer = util::make_timer(
         Duration::from_secs(config.shard.login_server_conn_interval.get()),
+        true,
+    );
+    let mut db_conn_timer = util::make_timer(
+        Duration::from_secs(config.shard.login_server_conn_interval.get()), // TODO: config111
         true,
     );
     let mut save_timer = util::make_timer(
@@ -176,6 +178,9 @@ async fn main() -> FFResult<()> {
             }
             _ = login_conn_timer.tick() => {
                 log_if_failed(connect_to_login_server(&mut server, &mut *state.lock().await).await);
+            }
+            _ = db_conn_timer.tick() => {
+                log_if_failed(db_init(Severity::Fatal).await);
             }
             _ = status_timer.tick() => {
                 let clients = server.get_clients().await;

--- a/src/bin/shard/main.rs
+++ b/src/bin/shard/main.rs
@@ -35,6 +35,8 @@ async fn main() -> FFResult<()> {
     color_eyre::install().unwrap();
     let _cleanup = Cleanup {};
 
+    db_init(Severity::Fatal).await?;
+
     let log_rx = log_init();
     let config = config_init()?;
     let mut logger = Logger::new(log_rx, &config.shard.log_path.get());
@@ -48,7 +50,6 @@ async fn main() -> FFResult<()> {
         None
     };
 
-    db_init(Severity::Fatal).await?;
     tdata_init()?;
     scripting_init()?;
 

--- a/src/bin/shard/main.rs
+++ b/src/bin/shard/main.rs
@@ -61,7 +61,7 @@ async fn main() -> FFResult<()> {
         true,
     );
     let mut db_conn_timer = util::make_timer(
-        Duration::from_secs(config.shard.login_server_conn_interval.get()), // TODO: config111
+        Duration::from_secs(config.general.db_conn_retry_interval.get()),
         true,
     );
     let mut save_timer = util::make_timer(

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -119,6 +119,27 @@ define_db_api! {
     delete_player(&self, pc_uid: BigInt) -> ();
 }
 
+fn format_db_conn_error(parent_error: FFError) -> FFError {
+    let expected_error_message = "Error occurred while creating a new object: error connecting to server";
+
+    if let Some(parent_parent) = parent_error.get_parent() {
+        if parent_parent.get_msg() == expected_error_message {
+            // If it's the common case of not being able to connect to the DB,
+            // just print a concise, readable error message.
+            return FFError::build(
+                Severity::Warning,
+                "Failed to connect to database".to_string(),
+            );
+        }
+    }
+
+    // If it's some other DB connection error, print the pseudo-stack trace.
+    FFError::build(
+        Severity::Warning,
+        "Unexpected error while connecting to database".to_string(),
+    ).with_parent(parent_error)
+}
+
 async fn db_connect(config: &GeneralConfig) -> FFResult<DbBackend> {
     let _db_impl: Option<FFResult<DbBackend>> = None;
 
@@ -127,10 +148,7 @@ async fn db_connect(config: &GeneralConfig) -> FFResult<DbBackend> {
 
     match _db_impl {
         Some(Ok(db)) => Ok(db),
-        Some(Err(_)) => Err(FFError::build(
-            Severity::Fatal,
-            "Failed to connect to database".to_string(),
-        )),
+        Some(Err(parent_error)) => Err(format_db_conn_error(parent_error)),
         None => Err(FFError::build(
             Severity::Fatal,
             "No database implementation enabled; please enable one through a feature".to_string(),

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -120,22 +120,23 @@ define_db_api! {
 }
 
 async fn db_connect(config: &GeneralConfig) -> FFResult<DbBackend> {
-    let _db_impl: Option<FFResult<DbBackend>> = None;
+    loop {
+        let _db_impl: Option<FFResult<DbBackend>> = None;
 
-    #[cfg(feature = "postgres")]
-    let _db_impl = Some(postgresql::PostgresDatabase::connect(config).await);
+        #[cfg(feature = "postgres")]
+        let _db_impl = Some(postgresql::PostgresDatabase::connect(config).await);
 
-    match _db_impl {
-        Some(Ok(db)) => Ok(db),
-        Some(Err(e)) => Err(FFError::build(
-            Severity::Fatal,
-            "Failed to connect to database".to_string(),
-        )
-        .with_parent(e)),
-        None => Err(FFError::build(
-            Severity::Fatal,
-            "No database implementation enabled; please enable one through a feature".to_string(),
-        )),
+        match _db_impl {
+            Some(Ok(db)) => return Ok(db),
+            Some(Err(_)) => {
+                log(Severity::Warning, "Failed to connect to DB. Retrying...");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            },
+            None => return Err(FFError::build(
+                Severity::Fatal,
+                "No database implementation enabled; please enable one through a feature".to_string(),
+            )),
+        }
     }
 }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -120,32 +120,27 @@ define_db_api! {
 }
 
 async fn db_connect(config: &GeneralConfig) -> FFResult<DbBackend> {
-    loop {
-        let _db_impl: Option<FFResult<DbBackend>> = None;
+    let _db_impl: Option<FFResult<DbBackend>> = None;
 
-        #[cfg(feature = "postgres")]
-        let _db_impl = Some(postgresql::PostgresDatabase::connect(config).await);
+    #[cfg(feature = "postgres")]
+    let _db_impl = Some(postgresql::PostgresDatabase::connect(config).await);
 
-        match _db_impl {
-            Some(Ok(db)) => return Ok(db),
-            Some(Err(_)) => {
-                log(Severity::Warning, "Failed to connect to DB. Retrying...");
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            },
-            None => return Err(FFError::build(
-                Severity::Fatal,
-                "No database implementation enabled; please enable one through a feature".to_string(),
-            )),
-        }
+    match _db_impl {
+        Some(Ok(db)) => Ok(db),
+        Some(Err(_)) => Err(FFError::build(
+            Severity::Fatal,
+            "Failed to connect to database".to_string(),
+        )),
+        None => Err(FFError::build(
+            Severity::Fatal,
+            "No database implementation enabled; please enable one through a feature".to_string(),
+        )),
     }
 }
 
 pub async fn db_init(error_severity: Severity) -> FFResult<&'static Database<DbBackend>> {
     if DB.get().is_some() {
-        return Err(FFError::build(
-            Severity::Warning,
-            "Database already initialized".to_string(),
-        ));
+        return Ok(db_get());
     }
 
     let _ = DB_ERROR_SEVERITY.set(error_severity);

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -120,7 +120,8 @@ define_db_api! {
 }
 
 fn format_db_conn_error(parent_error: FFError) -> FFError {
-    let expected_error_message = "Error occurred while creating a new object: error connecting to server";
+    let expected_error_message =
+        "Error occurred while creating a new object: error connecting to server";
 
     if let Some(parent_parent) = parent_error.get_parent() {
         if parent_parent.get_msg() == expected_error_message {
@@ -137,7 +138,8 @@ fn format_db_conn_error(parent_error: FFError) -> FFError {
     FFError::build(
         Severity::Warning,
         "Unexpected error while connecting to database".to_string(),
-    ).with_parent(parent_error)
+    )
+    .with_parent(parent_error)
 }
 
 async fn db_connect(config: &GeneralConfig) -> FFResult<DbBackend> {

--- a/src/database/postgresql.rs
+++ b/src/database/postgresql.rs
@@ -24,20 +24,21 @@ use crate::{
 
 impl From<postgres::Error> for FFError {
     fn from(e: postgres::Error) -> Self {
-        let underlying_error = if let Some(ue) = e.as_db_error() {
-            ue.to_string()
+        let e = if let Some(e) = e.as_db_error() {
+            e.to_string()
         } else {
             e.to_string()
         };
+
         FFError::build(db_error_severity(), "Database error".to_string())
-            .with_parent(FFError::build(Severity::Debug, underlying_error))
+            .with_parent(FFError::build(Severity::Debug, e))
     }
 }
 impl From<deadpool_postgres::PoolError> for FFError {
     fn from(e: deadpool_postgres::PoolError) -> Self {
-        let underlying_error = if let deadpool_postgres::PoolError::Backend(ref ue) = e {
-            if let Some(ue) = ue.as_db_error() {
-                ue.to_string()
+        let e = if let deadpool_postgres::PoolError::Backend(ref e) = e {
+            if let Some(e) = e.as_db_error() {
+                e.to_string()
             } else {
                 e.to_string()
             }
@@ -46,7 +47,7 @@ impl From<deadpool_postgres::PoolError> for FFError {
         };
 
         FFError::build(db_error_severity(), "Database pool error".to_string())
-            .with_parent(FFError::build(Severity::Debug, underlying_error))
+            .with_parent(FFError::build(Severity::Debug, e))
     }
 }
 

--- a/src/database/postgresql.rs
+++ b/src/database/postgresql.rs
@@ -24,14 +24,29 @@ use crate::{
 
 impl From<postgres::Error> for FFError {
     fn from(e: postgres::Error) -> Self {
+        let underlying_error = if let Some(ue) = e.as_db_error() {
+            ue.to_string()
+        } else {
+            e.to_string()
+        };
         FFError::build(db_error_severity(), "Database error".to_string())
-            .with_parent(FFError::build(Severity::Debug, e.to_string()))
+            .with_parent(FFError::build(Severity::Debug, underlying_error))
     }
 }
 impl From<deadpool_postgres::PoolError> for FFError {
     fn from(e: deadpool_postgres::PoolError) -> Self {
+        let underlying_error = if let deadpool_postgres::PoolError::Backend(ref ue) = e {
+            if let Some(ue) = ue.as_db_error() {
+                ue.to_string()
+            } else {
+                e.to_string()
+            }
+        } else {
+            e.to_string()
+        };
+
         FFError::build(db_error_severity(), "Database pool error".to_string())
-            .with_parent(FFError::build(Severity::Debug, e.to_string()))
+            .with_parent(FFError::build(Severity::Debug, underlying_error))
     }
 }
 


### PR DESCRIPTION
The initial DB connection now retries on a timer, allowing the login and shard servers to be started before the database.

* Failure to reach the DB prints a simple, readable error message
* Other DB connection errors like auth failures print more detailed error messages
* Improved underlying error message extraction from errors on other DB operations as well